### PR TITLE
Clipping implemented + Multiple bugfixes in the SharpDX render context

### DIFF
--- a/Source/OxyPlot.SharpDX/OxyPlot.SharpDX.projitems
+++ b/Source/OxyPlot.SharpDX/OxyPlot.SharpDX.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CacherRenderContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderUnits\ClipRectRenderUnit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderUnits\EllipseRenderUnit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderUnits\GeometryRenderUnit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderUnits\ImageRenderUnit.cs" />

--- a/Source/OxyPlot.SharpDX/RenderUnits/ClipRectRenderUnit.cs
+++ b/Source/OxyPlot.SharpDX/RenderUnits/ClipRectRenderUnit.cs
@@ -1,0 +1,62 @@
+﻿namespace OxyPlot.SharpDX
+{
+    using global::SharpDX;
+    using global::SharpDX.Direct2D1;
+
+    /// <summary>
+    /// Represents clipping settings during rendering.
+    /// </summary>
+    internal class ClipRectRenderUnit : IRenderUnit
+    {
+        /// <summary>
+        /// Clipping rect to set on a target.
+        /// </summary>
+        private RectangleF clipRect;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClipRectRenderUnit" /> class.
+        /// </summary>
+        /// <param name="clipRect">The clipping rect.</param>
+        public ClipRectRenderUnit(RectangleF clipRect)
+        {
+            this.clipRect = clipRect;
+        }
+
+        /// <summary>
+        /// Clips render target to the rect, stored in the current instance.
+        /// </summary>
+        /// <param name="renderTarget"></param>
+        public void Render(RenderTarget renderTarget)
+        {
+            if (clipRect != RectangleF.Empty)
+            {
+                renderTarget.PushAxisAlignedClip(clipRect, AntialiasMode.PerPrimitive);
+            }
+            else
+            {
+                renderTarget.PopAxisAlignedClip();
+            }
+        }
+
+        /// <summary>
+        /// Checks if current instance bounds intersects with viewport or not.
+        /// </summary>
+        /// <param name="viewport">The viewport.</param>
+        /// <returns>Return <c>True</c> if bounds intersects with viewport, otherwise <c>False</c>.</returns>
+        public bool CheckBounds(RectangleF viewport)
+        {
+            // Clipping operation should always be performed. If it's outside of the viewport it will clip
+            // out the entire scene and therefore should still be applied.
+            return true;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting
+        /// unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            // Neither managed nor unmanaged resources are held - noop
+        }
+    }
+}


### PR DESCRIPTION
This is how included SimpleDemo looked before these fixes
![simpledemo](https://user-images.githubusercontent.com/9646611/31856904-6ac09ae4-b683-11e7-8a4d-8a9a157f52a2.png)

It also didn't correctly render overlapping ellipses (MarkerType.Circle with MarkerFill being anything but Transparent) and Polygons