### PR TITLE
Issue 7 fix, ContainsKey check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Clipping
 - Text rotation (#1075)
+- Image Annotations (#7)

--- a/Source/OxyPlot.SharpDX/CacherRenderContext.cs
+++ b/Source/OxyPlot.SharpDX/CacherRenderContext.cs
@@ -717,7 +717,12 @@ namespace OxyPlot.SharpDX
                 this.imagesInUse.Add(image);
             }
 
-            Bitmap res;
+			if (this.imageCache.ContainsKey(image))
+			{
+				return this.imageCache[image];
+			}
+
+			Bitmap res;
             using (var stream = new MemoryStream(image.GetData()))
             {
                 var decoder = new BitmapDecoder(this.wicFactory, stream, DecodeOptions.CacheOnDemand);


### PR DESCRIPTION
Fixes #7

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Added a containsKey check to the GetBitmap function in the CacherRenderContext

@oxyplot/admins
