### PR TITLE
Fix issue #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Clipping
 - Text rotation (#1075)
+- Polygon geometry fill rendering (#6)

--- a/Source/OxyPlot.SharpDX/CacherRenderContext.cs
+++ b/Source/OxyPlot.SharpDX/CacherRenderContext.cs
@@ -250,7 +250,7 @@ namespace OxyPlot.SharpDX
         {
             var path = new PathGeometry(this.d2dFactory);
             var sink = path.Open();
-            sink.BeginFigure(points[0].ToVector2(aliased), FigureBegin.Hollow);
+            sink.BeginFigure(points[0].ToVector2(aliased), this.GetBrush(fill) == null ? FigureBegin.Hollow : FigureBegin.Filled);
 
             sink.AddLines(points.Skip(1).Select(pt => (dx.Mathematics.Interop.RawVector2)pt.ToVector2(aliased)).ToArray());
             sink.EndFigure(FigureEnd.Closed);


### PR DESCRIPTION
Fixes #6 

I am not sure the conditional is necessary. If you just always use FigureBegin.Filled it works fine. I am not sure why FigureBegin.Hollow is even an option in the DX libraries if you can just fill with a null fill brush. Nevertheless, assuming there is a reason for these two types, I added the check to be on the safe side.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins
