### PR TITLE
Issue8 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ All notable changes to this project will be documented in this file.
 - Text rotation (#1075)
 - Polygon geometry fill rendering (#6)
 - Image Annotations (#7)
+- MeasureText fixed in cases where string is null or empty

--- a/Source/OxyPlot.SharpDX/CacherRenderContext.cs
+++ b/Source/OxyPlot.SharpDX/CacherRenderContext.cs
@@ -433,9 +433,9 @@ namespace OxyPlot.SharpDX
                 fontFamily = "Arial";
             }
 
-            if (text == null)
+            if (string.IsNullOrEmpty(text))
             {
-                text = string.Empty;
+                return OxySize.Empty;
             }
 
             var format = new TextFormat(this.dwtFactory, fontFamily, GetFontWeight(fontWeight), FontStyle.Normal, FontStretch.Normal, (float)fontSize);


### PR DESCRIPTION
Fixes #8 

The issue was that empty and null strings were being measured, returning the font height and 0 width. This was creating additional space wherever a text could be shown but was not.

The behaviour implemented in this PR is copied directly from the original oxyplot CanvasRenderContext https://github.com/oxyplot/oxyplot/blob/fe84b034c1105fd0cd679d8cedd88d9c20fde417/Source/OxyPlot.Wpf/CanvasRenderContext.cs
and simply returns OxySize.Empty for null and empty strings

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

@oxyplot/admins
