### PR TITLE
Fix #24 Zooming via MouseWheel not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ SimpleDemo: Target .NET Core 3.1
 - MeasureText fixed in cases where string is null or empty
 - Fixed render extent not being set in ArrangeOverride step on WPF (#12)
 - Fixed zero dimensions crashing plot (#14)
+- Zooming via MouseWheel not working (#24)

--- a/Source/OxyPlot.SharpDX.Wpf/Themes/Generic.xaml
+++ b/Source/OxyPlot.SharpDX.Wpf/Themes/Generic.xaml
@@ -59,9 +59,7 @@
                 <ControlTemplate TargetType="local:PlotView">
                     <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
                         <!-- Don't set CacheMode="BitmapCache" as this makes the text look ugly -->
-                        <ScrollViewer Focusable="False" CanContentScroll="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" >
-                            <local:PlotImage x:Name="PART_PlotImage" PlotHeight="{TemplateBinding PlotHeight}" PlotWidth="{TemplateBinding PlotWidth}" PlotModel="{TemplateBinding Model}" IsHitTestVisible="False" />
-                        </ScrollViewer>
+                        <local:PlotImage x:Name="PART_PlotImage" PlotHeight="{TemplateBinding PlotHeight}" PlotWidth="{TemplateBinding PlotWidth}" PlotModel="{TemplateBinding Model}" IsHitTestVisible="False" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
Fixes #24.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Remove `ScrollViewer` around `PlotView`, as this caused the `PlotView` to not receive the MouseWheel events and served no obvious function.

@oxyplot/admins
